### PR TITLE
Updating AWS SDK

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-java-sdk-ssm</artifactId>
-            <version>1.11.566</version>
+            <version>1.11.704</version>
         </dependency>
 
         <!-- Test libraries -->

--- a/readme.md
+++ b/readme.md
@@ -10,7 +10,7 @@ The Spring Boot Parameter Store Integration is a tiny library used to integrate 
 The library uses:
 
 - [Spring Boot](https://spring.io/projects/spring-boot) 1.5.21.RELEASE
-- [AWS Java SDK](https://aws.amazon.com/sdk-for-java/) 1.11.566
+- [AWS Java SDK](https://aws.amazon.com/sdk-for-java/) 1.11.704
 
 Those can be overridden in your `pom.xml`.  
 


### PR DESCRIPTION
The purpose of that update is to support proper IAM/Kubernetes integration.
Refs: https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts-minimum-sdk.html
