### PR TITLE
Replace nexus-staging-maven-plugin with central-publishing-maven-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -186,14 +186,15 @@
                         </executions>
                     </plugin>
                     <plugin>
-                        <groupId>org.sonatype.plugins</groupId>
-                        <artifactId>nexus-staging-maven-plugin</artifactId>
-                        <version>1.7.0</version>
+                        <groupId>org.sonatype.central</groupId>
+                        <artifactId>central-publishing-maven-plugin</artifactId>
+                        <version>0.9.0</version>
                         <extensions>true</extensions>
                         <configuration>
-                            <serverId>ossrh</serverId>
-                            <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-                            <autoReleaseAfterClose>true</autoReleaseAfterClose>
+                            <publishingServerId>central</publishingServerId>
+                            <autoPublish>true</autoPublish>
+                            <waitUntil>published</waitUntil>
+                            <deploymentName>spring-boot-parameter-store-integration</deploymentName>
                         </configuration>
                     </plugin>
                     <plugin>
@@ -221,14 +222,4 @@
         </profile>
     </profiles>
 
-    <distributionManagement>
-        <snapshotRepository>
-            <id>ossrh</id>
-            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-        </snapshotRepository>
-        <repository>
-            <id>ossrh</id>
-            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-        </repository>
-    </distributionManagement>
 </project>


### PR DESCRIPTION
Migrate from the deprecated `nexus-staging-maven-plugin` (oss.sonatype.org) to the new `central-publishing-maven-plugin` (central.sonatype.com) for publishing releases to Maven Central.

### Changes
- Replace `nexus-staging-maven-plugin` with `central-publishing-maven-plugin` 0.9.0
- Update configuration to use new plugin settings (`autoPublish`, `waitUntil`)
- Remove legacy `distributionManagement` section (no longer needed with the new plugin)

Reference: https://github.com/jebeaudet/flyway-validator-maven-plugin/blob/main/pom.xml